### PR TITLE
added possibility to upload docs file on existing endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@nestjs/testing": "^10.0.0",
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.2",
+        "@types/multer": "^1.4.12",
         "@types/node": "^20.3.1",
         "@types/supertest": "^6.0.0",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
@@ -1998,6 +1999,15 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "dev": true
+    },
+    "node_modules/@types/multer": {
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.12.tgz",
+      "integrity": "sha512-pQ2hoqvXiJt2FP9WQVLPRO+AmiIm/ZYkavPlIQnx282u4ZrVdztx0pkh3jjpQt0Kz+YI0YhSG264y08UJKoUQg==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.17.6",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@nestjs/testing": "^10.0.0",
     "@types/express": "^5.0.0",
     "@types/jest": "^29.5.2",
+    "@types/multer": "^1.4.12",
     "@types/node": "^20.3.1",
     "@types/supertest": "^6.0.0",
     "@typescript-eslint/eslint-plugin": "^8.0.0",

--- a/src/endpoint-tester/endpoint-tester.controller.ts
+++ b/src/endpoint-tester/endpoint-tester.controller.ts
@@ -1,8 +1,9 @@
 /* eslint-disable prettier/prettier */
-import { Controller, Param, Post } from '@nestjs/common';
-import { ApiBadRequestResponse, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Controller, Param, Post, UploadedFile, UseInterceptors } from '@nestjs/common';
+import { ApiBadRequestResponse, ApiBody, ApiConsumes, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { EndpointTesterService } from './endpoint-tester.service';
 import { FileUploadtDto } from './dto/endpoint-tester.dto';
+import { FileInterceptor } from '@nestjs/platform-express';
 
 @ApiTags('Endpoint Tester')
 @Controller('endpoint-tester')
@@ -10,12 +11,34 @@ export class EndpointTesterController {
   constructor(private endpointTesterService: EndpointTesterService){}
 
 
-    @Post()
-    @ApiOperation({summary: "List all possible e2e scenarious for agiven endpoint"})
-    @ApiBadRequestResponse({description: "Invalid data provided."})
-    @ApiOkResponse({description: 'OK', type: String, isArray: true})
-    generateScenarious(@Param() params: FileUploadtDto){
-       console.log(params)
-      return this.endpointTesterService.generateScenarious()
+  @Post()
+  @UseInterceptors(FileInterceptor('file'))
+  @ApiOperation({ summary: "List all possible e2e scenarios for a given endpoint" })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    description: 'Upload a YAML file',
+    type: 'multipart/form-data',
+    required: true,
+    schema: {
+      type: 'object',
+      properties: {
+        file: {
+          type: 'string',
+          format: 'binary',
+        },
+      },
+    },
+  })
+  @ApiBadRequestResponse({ description: "Invalid data provided." })
+  @ApiOkResponse({ description: 'OK', type: String, isArray: true })
+  generateScenarios(
+    @Param() params: FileUploadtDto,
+    @UploadedFile() file: Express.Multer.File
+  ) {
+    if (file.mimetype !== 'application/x-yaml' && file.mimetype !== 'text/yaml') {
+      throw new Error('Only .yml files are allowed');
     }
+    console.log(file);
+  }
+  
 }


### PR DESCRIPTION

Updated endpoint ` POST -> /endpoint-tester`

- Now it is possible to upload docs file on this endpoint 
- Added swagger documentation for this new parameter
- Logic Implementation will be added in the future 